### PR TITLE
[PL-CICD-CI]

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,4 +80,7 @@ jobs:
           MONGO_HOST: ${{ secrets.MONGO_HOST }}
           MONGO_PORT: ${{ secrets.MONGO_PORT }}
           MONGO_DATABASE: ${{ secrets.MONGO_DATABASE }}
+          EPIC_GAMES_CLIENT_ID: ${{ secrets.EPIC_GAMES_CLIENT_ID }}
+          EPIC_GAMES_CLIENT_SECRET: ${{ secrets.EPIC_GAMES_CLIENT_SECRET }}
+          EPIC_GAMES_DEPLOYMENT_ID: ${{ secrets.EPIC_GAMES_DEPLOYMENT_ID }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,83 @@
+name: Auto delploy Docker
+
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: devlink-server
+          IMAGE_TAG: latest
+        run: |
+          docker buildx build --platform=linux/amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYYMMDD_HH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Generate deployment package
+        run: |
+          mkdir -p deploy
+          cp Dockerrun.aws.json deploy/Dockerrun.aws.json
+          cd deploy && zip -r deploy.zip .
+
+      - name: Beanstalk Deploy
+        uses: einaregilsson/beanstalk-deploy@v14
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }} ## 계정 ACCESS KEY 값
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: ${{ secrets.EB_APP_NAME }} ## AWS EB 애플리케이션 이름
+          environment_name: ${{ secrets.EB_ENV_NAME }} ## AWS EB 환경 이름
+          version_label: earth-docker-${{ steps.current-time.outputs.formattedTime }}
+          region: ${{ secrets.AWS_REGION }}    ## ap-northeast-2
+          deployment_package: deploy/deploy.zip
+          wait_for_environment_recovery: 200
+        env:
+          MYSQL_URL: ${{ secrets.MYSQL_URL }}
+          MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          MONGO_USERNAME: ${{ secrets.MONGO_USERNAME }}
+          MONGO_PASSWORD: ${{ secrets.MONGO_PASSWORD }}
+          MONGO_HOST: ${{ secrets.MONGO_HOST }}
+          MONGO_PORT: ${{ secrets.MONGO_PORT }}
+          MONGO_DATABASE: ${{ secrets.MONGO_DATABASE }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:17
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,12 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name":  "ecr url:tag명",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": 8443
+    }
+  ]
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,14 +21,14 @@ spring:
             user-name-attribute: sub
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://125.132.216.190:15531/devlink
+    url: ${MYSQL_URL}
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
   data:
     mongodb:
-      host: 125.132.216.190
-      port: 15532
-      database: devlink
+      host: ${MONGO_HOST}
+      port: ${MONGO_PORT}
+      database: ${MONGO_DATABASE}
       username: ${MONGO_USERNAME}
       password: ${MONGO_PASSWORD}
   jpa:


### PR DESCRIPTION
## 작업 개요

`dev` 브랜치의 Spring Boot 애플리케이션을 Docker 이미지로 빌드해 Amazon ECR에 푸시하고, Elastic Beanstalk에 배포하는 GitHub Actions 워크플로를 추가했습니다. 배포 환경에서 데이터베이스 설정을 주입할 수 있도록 기존 고정값도 환경변수로 전환했습니다.

## 주요 변경 사항

### GitHub Actions 배포 워크플로 구성

- `dev` 브랜치의 push와 pull request를 실행 조건으로 설정
- Temurin JDK 17 환경에서 Gradle 빌드 수행
- AWS 자격 증명 설정 및 Amazon ECR 로그인 단계 추가
- `linux/amd64` Docker 이미지를 빌드해 `devlink-server:latest`로 ECR에 푸시
- `Dockerrun.aws.json`을 압축한 배포 패키지 생성
- 실행 시각을 버전 라벨에 포함해 Elastic Beanstalk로 배포

### 컨테이너 실행 환경 추가

- Eclipse Temurin 17 기반 `Dockerfile` 추가
- Gradle 빌드 결과 JAR을 이미지에 포함하고 `java -jar`로 실행
- Elastic Beanstalk 단일 컨테이너 배포를 위한 `Dockerrun.aws.json` 추가
- 애플리케이션 컨테이너 포트를 `8443`으로 설정

### 실행 환경 설정 외부화

- MySQL 접속 URL을 `MYSQL_URL` 환경변수로 전환
- MongoDB host, port, database를 각각 환경변수로 전환
- 기존 username과 password 환경변수 방식은 유지

## 변경 규모

- 변경 파일: 4개
- 추가: 109줄
- 삭제: 4줄

