### PR TITLE
Feat: CI/CD 파일 수정

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,6 @@ name: Auto delploy Docker
 on:
   push:
     branches: [ "dev" ]
-  pull_request:
-    branches: [ "dev" ]
 
 jobs:
   build-and-push-image:

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name":  "ecr url:tag명",
+    "Name":  "221082200491.dkr.ecr.ap-northeast-2.amazonaws.com/devlink-server:latest",
     "Update": "true"
   },
   "Ports": [


### PR DESCRIPTION
## 작업 개요

앞서 추가한 CI/CD 설정에서 워크플로 실행 조건과 Elastic Beanstalk 배포 이미지 경로를 수정했습니다. 배포 워크플로는 `dev` 브랜치 push 시 실행되도록 조정하고, `Dockerrun.aws.json`에는 실제 ECR 이미지 주소를 지정했습니다.

## 주요 변경 사항

### 배포 워크플로 실행 조건 변경

- `.github/workflows/docker-image.yml`의 pull request 트리거 제거
- `dev` 브랜치 push를 기준으로 Docker 이미지 빌드와 배포가 실행되도록 변경

### Elastic Beanstalk 배포 이미지 지정

- `Dockerrun.aws.json`의 이미지 이름을 임시 문자열에서 ECR의 `devlink-server:latest` 이미지 주소로 변경
- Elastic Beanstalk가 배포 시 사용할 컨테이너 이미지를 명확히 지정

## 변경 규모

- 변경 파일: 2개
- 추가: 1줄
- 삭제: 3줄

