### PR TITLE
Revert "Feat: CI/CD 파일 수정"

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,8 @@ name: Auto delploy Docker
 on:
   push:
     branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
 
 jobs:
   build-and-push-image:

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name":  "221082200491.dkr.ecr.ap-northeast-2.amazonaws.com/devlink-server:latest",
+    "Name":  "ecr url:tag명",
     "Update": "true"
   },
   "Ports": [


### PR DESCRIPTION
## 작업 개요

PR #75에서 변경한 CI/CD 설정을 되돌려 이전 상태로 복원했습니다. 새로운 배포 동작을 추가한 PR이 아니라, 워크플로 실행 조건과 `Dockerrun.aws.json`의 이미지 설정을 #75 적용 전 상태로 되돌린 변경입니다.

## 주요 변경 사항

### GitHub Actions 실행 조건 복원

- `dev` 브랜치 pull request 트리거 복원
- `dev` 브랜치 push와 pull request에서 워크플로가 실행되는 기존 구성으로 변경

### 배포 이미지 설정 복원

- `Dockerrun.aws.json`에 지정했던 ECR 이미지 주소 제거
- 이미지 이름을 기존 임시 문자열인 `ecr url:tag명`으로 복원

## 관련 PR

- Revert 대상: #75

## 변경 규모

- 변경 파일: 2개
- 추가: 3줄
- 삭제: 1줄
