### PR TITLE
fix: Channel 도메인 저장시 createdAt이 저장 안되는 문제 해결

### DIFF
--- a/src/main/java/com/mtvs/devlinkbackend/channel/entity/Channel.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/entity/Channel.java
@@ -6,10 +6,10 @@ import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mongodb.core.annotation.Collation;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -22,8 +22,8 @@ public class Channel {
     @Id
     private String channelId;
 
-    @Field(name = "owner_id")
-    private String ownerId;
+    @Field(name = "user_id")
+    private Long userId;
 
     private List<PositionType> positionTypes; // 여러 개의 position과 type 저장
 
@@ -33,9 +33,8 @@ public class Channel {
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 
-    public Channel(String ownerId, List<PositionType> positionTypes) {
-        this.channelId = UUID.randomUUID().toString();
-        this.ownerId = ownerId;
+    public Channel(Long userId, List<PositionType> positionTypes) {
+        this.userId = userId;
         this.positionTypes = positionTypes;
     }
 

--- a/src/main/java/com/mtvs/devlinkbackend/channel/service/ChannelService.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/service/ChannelService.java
@@ -6,26 +6,40 @@ import com.mtvs.devlinkbackend.channel.dto.response.ChannelSingleResponseDTO;
 import com.mtvs.devlinkbackend.channel.dto.request.ChannelUpdateRequestDTO;
 import com.mtvs.devlinkbackend.channel.entity.Channel;
 import com.mtvs.devlinkbackend.channel.repository.ChannelRepository;
+import com.mtvs.devlinkbackend.user.command.model.entity.User;
+import com.mtvs.devlinkbackend.user.query.service.UserViewService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
 public class ChannelService {
     private final ChannelRepository channelRepository;
+    private final UserViewService userViewService;
 
-    public ChannelService(ChannelRepository channelRepository) {
+    public ChannelService(ChannelRepository channelRepository, UserViewService userViewService) {
         this.channelRepository = channelRepository;
+        this.userViewService = userViewService;
     }
 
     // 새 채널 저장
     @Transactional
     public ChannelSingleResponseDTO saveChannel(ChannelRegistRequestDTO channelRegistRequestDTO, String accountId) {
-        return new ChannelSingleResponseDTO(channelRepository.save(new Channel(
-                accountId,
+        User user = userViewService.findUserByEpicAccountId(accountId);
+        if(user == null)
+            throw new IllegalArgumentException("잘못된 에픽 계정으로 접근중");
+
+        Channel channel = channelRepository.save(new Channel(
+                user.getUserId(),
                 channelRegistRequestDTO.getPositionTypes()
-        )));
+        ));
+
+        user.getChannelList().add(channel.getChannelId());
+
+        return new ChannelSingleResponseDTO(channel);
     }
 
     // 모든 채널 조회
@@ -42,10 +56,14 @@ public class ChannelService {
     // ID로 채널 업데이트
     @Transactional
     public ChannelSingleResponseDTO updateChannel(ChannelUpdateRequestDTO channelUpdateRequestDTO, String accountId) {
+        User user = userViewService.findUserByEpicAccountId(accountId);
+        if(user == null)
+            throw new IllegalArgumentException("잘못된 에픽계정으로 접근중");
+
         Optional<Channel> channel = channelRepository.findById(channelUpdateRequestDTO.getChannelId());
         if (channel.isPresent()) {
             Channel foundChannel = channel.get();
-            if(foundChannel.getOwnerId().equals(accountId)) {
+            if(foundChannel.getUserId().equals(user.getUserId())) {
                 foundChannel.setPositionTypes(channelUpdateRequestDTO.getPositionTypes());
                 return new ChannelSingleResponseDTO(foundChannel);
             } else throw new IllegalArgumentException("주인이 아닌 다른 사용자 계정으로 채널 수정 시도중");
@@ -54,6 +72,15 @@ public class ChannelService {
 
     // ID로 채널 삭제
     public void deleteChannel(String channelId) {
+        Channel channel = channelRepository.findById(channelId).orElse(null);
+        if(channel == null)
+            throw new IllegalArgumentException("잘못된 ChannelId로 접근중");
+
+        User user = userViewService.findUserByUserId(channel.getUserId()).getData();
+        if (user == null)
+            throw new IllegalArgumentException("잘못된 UserId로 접근중");
+
+        user.getChannelList().remove(channelId);
         channelRepository.deleteById(channelId);
     }
 }


### PR DESCRIPTION
<!-- Pull Request Template -->
정보 
---
|    작성일    | 작성자 | 
| :--------- | --------- |
| 2024/11/07 | Hexeong |

<!-- 제목 -->
제목
---------
fix: Channel 도메인 저장시 createdAt이 저장 안되는 문제 해결

내용
---------
Channel Document에 대해서 생성 시 기존 생성자는 UUID.random()으로 직접 id 값을 주입하는 시스템. 하지만 @CreatedDate는 isNew()라는 메서드로 확인을 한다음 true면 실행. isNew()의 판단 기준이 id값이 null인지 확인하는 것. 따라서 생성자에서 UUID.random으로 직접 주입하는 것을 막아서 해결

추가 변경된 점:
- 기존의 사용자의 에픽 계정 ID인 owner_id가 RDB의 User도메인의 PK값인 userId로 변경됨. 바뀐 테이블 정보의 User 주 식별자로 userId를 지정했기 때문에 이와 같이 수정

체크 리스트
---------
<!-- 완료한 부분에 x를 넣어 주세요 `x` -->
<!-- 무엇인지 모르겠으면 질문하세요! 우리는 언제나 질문에 성심성의것 답변할 준비가 되어있습니다. -->

- [x] PR 하기전 사전 이슈를 확인 완료하였습니다.
- [x] 충돌사항을 정검하였습니다.
- [x] 코드 스타일 가이드에 맞는지 확인하였습니다.
- [x] 기술적인 버그 발생 사항을 충분히 고려하였습니다.
- [x] 깃 로그를 정리 하였습니다.
- [x] 테스트 코드가 정상적으로 돌아가며 신뢰할 수 있습니다.

💯 완료
---------
🎉 수고 하셨습니다!! 🚀

🌈 코드에 기여함을 언제나 감사합니다.

PR 작업한 결과에 대하여 모든 코드는 공유, 배포, 수정, 복사 및 재배포 될 수 있음을 확인합니다.