### PR TITLE
[DS-memo-info-entity] Memo CRUD 완성

### DIFF
--- a/src/main/java/com/mtvs/devlinkbackend/channel/dto/request/MemoModifyDTO.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/dto/request/MemoModifyDTO.java
@@ -1,0 +1,14 @@
+package com.mtvs.devlinkbackend.channel.dto.request;
+
+import com.mtvs.devlinkbackend.channel.entity.Position;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MemoModifyDTO {
+    private String memoId;
+    private MemoRegistDTO memoRegistDTO;
+}

--- a/src/main/java/com/mtvs/devlinkbackend/channel/dto/request/MemoRegistDTO.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/dto/request/MemoRegistDTO.java
@@ -1,0 +1,14 @@
+package com.mtvs.devlinkbackend.channel.dto.request;
+
+import com.mtvs.devlinkbackend.channel.entity.Position;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MemoRegistDTO {
+    private String memoText;
+    private Position position;
+}

--- a/src/main/java/com/mtvs/devlinkbackend/channel/dto/response/IsSuccessDTO.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/dto/response/IsSuccessDTO.java
@@ -1,0 +1,13 @@
+package com.mtvs.devlinkbackend.channel.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class IsSuccessDTO {
+    private boolean isSuccess;
+    private String message;
+}

--- a/src/main/java/com/mtvs/devlinkbackend/channel/dto/response/MemoResponseDTO.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/dto/response/MemoResponseDTO.java
@@ -1,0 +1,15 @@
+package com.mtvs.devlinkbackend.channel.dto.response;
+
+import com.mtvs.devlinkbackend.channel.entity.MemoInfo;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MemoResponseDTO {
+    private List<MemoInfo> memoInfoList;
+}

--- a/src/main/java/com/mtvs/devlinkbackend/channel/entity/MemoInfo.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/entity/MemoInfo.java
@@ -1,5 +1,6 @@
 package com.mtvs.devlinkbackend.channel.entity;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -21,11 +23,15 @@ public class MemoInfo {
     @Id
     private String memoId;
 
-    @Field
+    @Indexed
     private String channelId;
 
     @Field
     private String memoText;
+
+    @NotNull
+    @Field
+    private Position position;
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/mtvs/devlinkbackend/channel/entity/MemoInfo.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/entity/MemoInfo.java
@@ -1,0 +1,35 @@
+package com.mtvs.devlinkbackend.channel.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Document(collection = "MEMOINFO")
+public class MemoInfo {
+    @Id
+    private String memoId;
+
+    @Field
+    private String channelId;
+
+    @Field
+    private String memoText;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/mtvs/devlinkbackend/channel/repository/MemoRepository.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/repository/MemoRepository.java
@@ -1,0 +1,9 @@
+package com.mtvs.devlinkbackend.channel.repository;
+
+import com.mtvs.devlinkbackend.channel.entity.MemoInfo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemoRepository extends MongoRepository<MemoInfo, String> {
+}

--- a/src/main/java/com/mtvs/devlinkbackend/channel/repository/MemoViewRepository.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/repository/MemoViewRepository.java
@@ -4,7 +4,9 @@ import com.mtvs.devlinkbackend.channel.entity.MemoInfo;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface MemoRepository extends MongoRepository<MemoInfo, String> {
+import java.util.List;
 
+@Repository
+public interface MemoViewRepository extends MongoRepository<MemoInfo,String> {
+    List<MemoInfo> findAllByChannelId(String channelId);
 }

--- a/src/main/java/com/mtvs/devlinkbackend/channel/service/MemoService.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/service/MemoService.java
@@ -1,0 +1,14 @@
+package com.mtvs.devlinkbackend.channel.service;
+
+import com.mtvs.devlinkbackend.channel.repository.MemoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemoService {
+    @Autowired
+    private MemoRepository memoRepository;
+
+
+}

--- a/src/main/java/com/mtvs/devlinkbackend/channel/service/MemoService.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/service/MemoService.java
@@ -1,7 +1,12 @@
 package com.mtvs.devlinkbackend.channel.service;
 
+import com.mtvs.devlinkbackend.channel.dto.request.MemoModifyDTO;
+import com.mtvs.devlinkbackend.channel.dto.request.MemoRegistDTO;
+import com.mtvs.devlinkbackend.channel.dto.response.IsSuccessDTO;
+import com.mtvs.devlinkbackend.channel.entity.MemoInfo;
 import com.mtvs.devlinkbackend.channel.repository.MemoRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,8 +16,58 @@ public class MemoService {
     private MemoRepository memoRepository;
 
     @Transactional
-    public Boolean deleteMemoById(String memoId) {
-        memoRepository.deleteById(memoId);
-        return !memoRepository.existsById(memoId);
+    public IsSuccessDTO registMemo(MemoRegistDTO memoRegistDTO, String channelId) {
+        IsSuccessDTO isSuccessDTO = new IsSuccessDTO();
+
+        try {
+            MemoInfo memo = new MemoInfo();
+            memo.setMemoText(memoRegistDTO.getMemoText());
+            memo.setPosition(memoRegistDTO.getPosition());
+            memo.setChannelId(channelId);
+            memoRepository.save(memo);
+            isSuccessDTO.setSuccess(true);
+            isSuccessDTO.setMessage("메모 등록 성공");
+        } catch (Exception e) {
+            isSuccessDTO.setSuccess(false);
+            isSuccessDTO.setMessage("메모 등록 실패");
+            e.printStackTrace();
+        }
+
+        return isSuccessDTO;
+    }
+
+    @Transactional
+    public IsSuccessDTO modifyMemo(MemoModifyDTO memoModifyDTO) {
+        IsSuccessDTO isSuccessDTO = new IsSuccessDTO();
+        try {
+            MemoInfo memo = memoRepository.findById(memoModifyDTO.getMemoId())
+                    .orElseThrow(() -> new RuntimeException("메모를 찾을 수 없습니다."));
+            memo.setMemoText(memoModifyDTO.getMemoRegistDTO().getMemoText());
+            memo.setPosition(memoModifyDTO.getMemoRegistDTO().getPosition());
+            memoRepository.save(memo);
+
+            isSuccessDTO.setSuccess(true);
+            isSuccessDTO.setMessage("메모 수정 성공");
+        } catch (Exception e) {
+            isSuccessDTO.setSuccess(false);
+            isSuccessDTO.setMessage("메모 수정 실패");
+            e.printStackTrace();
+        }
+        return isSuccessDTO;
+    }
+
+    @Transactional
+    public IsSuccessDTO deleteMemoById(String memoId) {
+        IsSuccessDTO isSuccessDTO = new IsSuccessDTO();
+        try {
+            memoRepository.deleteById(memoId);
+            isSuccessDTO.setSuccess(true);
+            isSuccessDTO.setMessage("메모 삭제 성공");
+        } catch (Exception e) {
+            isSuccessDTO.setSuccess(false);
+            isSuccessDTO.setMessage("메모 삭제 실패");
+            throw new RuntimeException(e);
+        }
+        return isSuccessDTO;
     }
 }

--- a/src/main/java/com/mtvs/devlinkbackend/channel/service/MemoService.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/service/MemoService.java
@@ -10,5 +10,9 @@ public class MemoService {
     @Autowired
     private MemoRepository memoRepository;
 
-
+    @Transactional
+    public Boolean deleteMemoById(String memoId) {
+        memoRepository.deleteById(memoId);
+        return !memoRepository.existsById(memoId);
+    }
 }

--- a/src/main/java/com/mtvs/devlinkbackend/channel/service/MemoViewService.java
+++ b/src/main/java/com/mtvs/devlinkbackend/channel/service/MemoViewService.java
@@ -1,0 +1,32 @@
+package com.mtvs.devlinkbackend.channel.service;
+
+import com.mtvs.devlinkbackend.channel.dto.response.MemoResponseDTO;
+import com.mtvs.devlinkbackend.channel.entity.Channel;
+import com.mtvs.devlinkbackend.channel.entity.MemoInfo;
+import com.mtvs.devlinkbackend.channel.repository.ChannelRepository;
+import com.mtvs.devlinkbackend.channel.repository.MemoRepository;
+import com.mtvs.devlinkbackend.channel.repository.MemoViewRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class MemoViewService {
+    @Autowired
+    private MemoViewRepository memoViewRepository;
+
+    @Transactional(readOnly = true)
+    public MemoResponseDTO getMemo(String channelId) {
+        try {
+            MemoResponseDTO memoResponseDTO = new MemoResponseDTO();
+            List<MemoInfo> memoInfo = memoViewRepository.findAllByChannelId(channelId);
+            memoResponseDTO.setMemoInfoList(memoInfo);
+            return memoResponseDTO;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/mtvs/devlinkbackend/project/controller/ProjectCommandController.java
+++ b/src/main/java/com/mtvs/devlinkbackend/project/controller/ProjectCommandController.java
@@ -82,16 +82,16 @@ public class ProjectCommandController {
             @ApiResponse(responseCode = "400", description = "잘못된 파라미터")
     })
     @PostMapping("/accept/epic/{projectId}/{teamId}")
-    public ResponseEntity<Map<String, String>> acceptProject(
+    public ResponseEntity<Map<String, Boolean>> acceptProject(
             @PathVariable(name = "projectId") Long projectId,
             @PathVariable(name = "teamId") Long teamId,
             @RequestHeader(name = "Authorization") String authorizationHeader) throws Exception {
         Long userId = jwtUtil.getUserIdByToken(authorizationHeader);
-        Map<String, String> response = new HashMap<>();
+        Map<String, Boolean> response = new HashMap<>();
         if(projectService.acceptTeam(userId, projectId, teamId)) {
-            response.put("isSuccess", "true");
+            response.put("isSuccess", true);
         } else {
-            response.put("isSuccess", "false");
+            response.put("isSuccess", false);
         }
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/mtvs/devlinkbackend/project/repository/ProjectRepository.java
+++ b/src/main/java/com/mtvs/devlinkbackend/project/repository/ProjectRepository.java
@@ -15,7 +15,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     @Transactional
     @Query("UPDATE Support s SET s.supportConfirmation = :confirmationStatus " +
             "WHERE s.projectId = :projectId AND s.teamId = :teamId " +
-            "AND EXISTS (SELECT 1 FROM Team t WHERE t.teamId = s.teamId AND t.leaderUserId = :userId)")
+            "AND EXISTS (SELECT 1 FROM Project p WHERE p.projectId = :projectId AND p.userId = :userId)")
     void updateSupportConfirmation(@Param("projectId") Long projectId,
                                    @Param("teamId") Long teamId,
                                    @Param("userId") Long userId,

--- a/src/test/java/com/mtvs/devlinkbackend/crud/MemoCRUDTest.java
+++ b/src/test/java/com/mtvs/devlinkbackend/crud/MemoCRUDTest.java
@@ -1,0 +1,132 @@
+package com.mtvs.devlinkbackend.crud;
+
+import com.mtvs.devlinkbackend.channel.dto.request.MemoModifyDTO;
+import com.mtvs.devlinkbackend.channel.dto.request.MemoRegistDTO;
+import com.mtvs.devlinkbackend.channel.dto.response.IsSuccessDTO;
+import com.mtvs.devlinkbackend.channel.dto.response.MemoResponseDTO;
+import com.mtvs.devlinkbackend.channel.entity.MemoInfo;
+import com.mtvs.devlinkbackend.channel.entity.Position;
+import com.mtvs.devlinkbackend.channel.entity.TileInfo;
+import com.mtvs.devlinkbackend.channel.repository.MemoRepository;
+import com.mtvs.devlinkbackend.channel.repository.MemoViewRepository;
+import com.mtvs.devlinkbackend.channel.service.MemoService;
+import com.mtvs.devlinkbackend.channel.service.MemoViewService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class MemoCRUDTest {
+    @Autowired
+    private MemoRepository memoRepository;
+
+    @Autowired
+    private MemoViewRepository memoViewRepository;
+
+    @Autowired
+    private MemoService memoService;
+
+    @Autowired
+    private MemoViewService memoViewService;
+
+    @Test
+    void TestRegistMemo() {
+        // 1. 메모 등록을 위한 DTO 생성
+        MemoRegistDTO dto = new MemoRegistDTO("메모 텍스트", new Position(1.0F, 2.0F, 3.0F));
+
+        // 2. 메모 등록 서비스 호출
+        // channelId를 "channel 1"로 설정하고, 메모 등록을 시도
+        IsSuccessDTO isSuccessDTO = memoService.registMemo(dto, "channel 1");
+
+        // 3. 등록 성공 여부 확인
+        assertThat(isSuccessDTO.isSuccess()).isTrue(); // 메모가 성공적으로 등록되었는지 검증
+    }
+
+    @Test
+    void TestReadMemo() {
+        // 1. 사용할 channelId 설정
+        String channelId = "test-channel";
+
+        // 2. 여러 개의 원본 데이터 생성 및 등록
+        for (int i = 0; i < 5; i++) {
+            MemoRegistDTO registDTO = new MemoRegistDTO("메모 텍스트 " + (i + 1), new Position(1.0F + i, 2.0F + i, 3.0F + i));
+            IsSuccessDTO isSuccessRegist = memoService.registMemo(registDTO, channelId); // channelId를 경로 매개변수로 전달
+            assertThat(isSuccessRegist.isSuccess()).isTrue(); // 등록 성공 여부 확인
+        }
+
+        // 3. 메모 조회 서비스 호출
+        MemoResponseDTO memoResponseDTO = memoViewService.getMemo(channelId);
+
+        // 4. 조회된 메모 확인
+        List<MemoInfo> memoInfoList = memoResponseDTO.getMemoInfoList();
+        assertThat(memoInfoList).isNotEmpty(); // 조회된 메모 리스트가 비어있지 않아야 함
+        assertThat(memoInfoList.size()).isEqualTo(5); // 등록한 메모의 수와 일치해야 함
+
+        // 5. 각 메모의 텍스트 및 위치 확인
+        for (int i = 0; i < memoInfoList.size(); i++) {
+            assertThat(memoInfoList.get(i).getMemoText()).isEqualTo("메모 텍스트 " + (i + 1)); // 텍스트 확인
+            assertThat(memoInfoList.get(i).getPosition()).isEqualTo(new Position(1.0F + i, 2.0F + i, 3.0F + i)); // 위치 확인
+        }
+    }
+
+    @Test
+    void TestModifyMemo() {
+        // 1. 원본 데이터 생성 및 등록
+        MemoRegistDTO registDTO = new MemoRegistDTO("원본 메모 텍스트", new Position(1.0F, 2.0F, 3.0F));
+        IsSuccessDTO isSuccessRegist = memoService.registMemo(registDTO, "1");
+        assertThat(isSuccessRegist.isSuccess()).isTrue(); // 등록 성공 여부 확인
+
+        // 2. 등록된 메모 조회
+        MemoInfo savedMemo = memoRepository.findAll().get(0); // 가장 최근에 등록된 메모 조회 (단일 테스트에서는 이 방법이 유효)
+
+        // 3. 수정할 데이터 준비
+        MemoModifyDTO dto = new MemoModifyDTO(savedMemo.getMemoId(), new MemoRegistDTO("수정된 메모 텍스트", new Position(4.0F, 5.0F, 6.0F)));
+
+        // 4. 메모 수정
+        IsSuccessDTO isSuccessDTO = memoService.modifyMemo(dto);
+        assertThat(isSuccessDTO.isSuccess()).isTrue();
+
+        // 5. 수정된 메모 확인
+        Optional<MemoInfo> optionalUpdatedMemo = memoRepository.findById(savedMemo.getMemoId());
+        assertThat(optionalUpdatedMemo).isPresent(); // 메모가 존재해야 함
+        assertThat(optionalUpdatedMemo.get().getMemoText()).isEqualTo("수정된 메모 텍스트"); // 수정된 텍스트 확인
+        assertThat(optionalUpdatedMemo.get().getPosition()).isEqualTo(new Position(4.0F, 5.0F, 6.0F)); // 수정된 위치 확인
+    }
+    @Test
+    void TestDeleteMemo() {
+        // 1. 사용할 channelId 설정
+        String channelId = "channel 1";
+
+        // 2. 메모 등록을 위한 DTO 생성
+        MemoRegistDTO dto = new MemoRegistDTO("삭제할 메모 텍스트", new Position(1.0F, 2.0F, 3.0F));
+
+        // 3. 메모 등록 서비스 호출
+        IsSuccessDTO isSuccessRegist = memoService.registMemo(dto, channelId);
+        assertThat(isSuccessRegist.isSuccess()).isTrue(); // 메모가 성공적으로 등록되었는지 확인
+
+        // 4. 등록된 메모 조회
+        MemoResponseDTO memoResponseDTO = memoViewService.getMemo(channelId);
+        List<MemoInfo> memoInfoList = memoResponseDTO.getMemoInfoList();
+        assertThat(memoInfoList).isNotEmpty(); // 조회된 메모 리스트가 비어있지 않아야 함
+        assertThat(memoInfoList.size()).isEqualTo(1); // 등록한 메모 수 확인
+
+        // 5. 메모 삭제 서비스 호출
+        String memoIdToDelete = memoInfoList.get(0).getMemoId(); // 삭제할 메모의 ID 가져오기
+        IsSuccessDTO isSuccessDelete = memoService.deleteMemoById(memoIdToDelete); // 메모 삭제 호출
+        assertThat(isSuccessDelete.isSuccess()).isTrue(); // 삭제 성공 여부 확인
+
+        // 6. 삭제 후 메모 조회하여 확인
+        MemoResponseDTO afterDeleteResponseDTO = memoViewService.getMemo(channelId);
+        List<MemoInfo> afterDeleteMemoInfoList = afterDeleteResponseDTO.getMemoInfoList();
+        assertThat(afterDeleteMemoInfoList).isEmpty(); // 삭제 후 메모 리스트는 비어있어야 함
+    }
+}


### PR DESCRIPTION
## 작업 개요

채널 안에서 사용하는 메모를 MongoDB 독립 문서로 저장하고, 등록·조회·수정·삭제할 수 있는 서비스 계층과 테스트를 추가했습니다. 메모는 `channelId`로 채널과 연결하고 위치 정보는 `Position`으로 함께 저장하도록 구성했습니다.

## 주요 변경 사항

### Memo 도메인 구성
- `MemoInfo` MongoDB Document 추가
  - `memoId`, `channelId`, `memoText`, `position` 저장
  - 생성·수정 시각 기록
  - 채널별 조회를 위한 `channelId` 인덱스 선언
- 등록·수정 요청 DTO와 조회·처리 결과 DTO 추가
  - `MemoRegistDTO`
  - `MemoModifyDTO`
  - `MemoResponseDTO`
  - `IsSuccessDTO`

### 저장 및 조회 로직
- `MemoRepository`를 통한 메모 등록·수정·삭제 구현
- `MemoViewRepository.findAllByChannelId`를 통한 채널별 메모 조회 구현
- 명령 책임은 `MemoService`, 조회 책임은 `MemoViewService`로 분리

### 프로젝트 수락 로직 보완
- 프로젝트 지원 수락 API의 `isSuccess` 응답을 문자열이 아닌 Boolean으로 변경
- 지원 수락 권한 확인 기준을 팀 리더가 아닌 프로젝트 작성자로 수정

## 테스트

`MemoCRUDTest`에서 다음 흐름을 검증했습니다.

- [x] 메모 등록
- [x] 채널별 메모 목록 조회
- [x] 메모 내용과 위치 수정
- [x] 메모 삭제 후 데이터 제거 확인

## 변경 규모

- 변경 파일: 12개
- 추가: 361줄
- 삭제: 5줄
